### PR TITLE
[#131426645] Fix router http health check

### DIFF
--- a/jobs/datadog-router/templates/http_check.yaml.erb
+++ b/jobs/datadog-router/templates/http_check.yaml.erb
@@ -2,7 +2,8 @@ init_config: {}
 
 instances:
   - name: gorouter
-    url: http://localhost:<%= p('router.port') %>/healthz
+    url: http://localhost:<%= p('router.port') %>/
     headers:
       User-Agent: <%= p('router.healthcheck_user_agent') %>
     collect_response_time: true
+    http_response_status_code: 200


### PR DESCRIPTION
# What

Fix router http health check, as
1. Health check is on /, not /healthz
2. Also check if response code is 200 OK. This will make datadog report
   status as DOWN (for this http check) when the response code is different.
# Testing

Deploy. You should see status (UP/DOWN) on this metric when creating a network check type monitor in datadog. You can also check if the new settings are correctly transferred to `/var/vcap/packages/datadog-agent/agent/conf.d/http_check.yaml` file after deployment.

You can also verify that healtcheck endpoint is on / by ssh-ing to the router and
`curl -H 'User-Agent: HTTP-Monitor/1.1' http://localhost:80` to which router responds 'ok' with 200 code when it's healthy
# Merging

After merging, tag this as 0.0.2 and update paas-cf to use the new version.
# Reviewing

not @mtekel or @paroxp 
