### PR TITLE
[#131355575] Fix NATS stream forwarder process check

### DIFF
--- a/jobs/datadog-nats/templates/process.yaml.erb
+++ b/jobs/datadog-nats/templates/process.yaml.erb
@@ -5,5 +5,5 @@ instances:
     search_string: ['gnatsd']
 
   - name: nats_stream_forwarder
-    search_string: ['ruby', 'nats_stream_forwarder.rb']
+    search_string: ['ruby /var/vcap/jobs/nats_stream_forwarder/bin/nats_stream_forwarder.rb']
     exact_match: False


### PR DESCRIPTION
# What

Story: [Check health of nats component](https://www.pivotaltracker.com/story/show/131355575)

https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease/pull/3 implemented checks for NATS and NATS stream forwarder. Unfortunately the NATS stream forwarder process check was checking for 'ruby' or 'nats_stream_forwarder.rb', and not 'ruby' and 'nats_stream_forwarder.rb'. The check now looks for the full string and doesn't give false positive.

This should be reviewed alongside https://github.com/alphagov/paas-cf/pull/545.
# How to review

See https://github.com/alphagov/paas-cf/pull/545
# Merge

See https://github.com/alphagov/paas-cf/pull/545
# Who can review

Not me
