### PR TITLE
[#131375807] Add Route Emitter process checks

### DIFF
--- a/jobs/datadog-route-emitter/spec
+++ b/jobs/datadog-route-emitter/spec
@@ -1,0 +1,12 @@
+---
+name: datadog-route-emitter
+packages: []
+
+templates:
+  process.yaml.erb: config/datadog-integrations/process.yaml
+  http_check.yaml.erb: config/datadog-integrations/http_check.yaml
+
+properties:
+  diego.route_emitter.debug_addr:
+    description: "address at which to serve debug info"
+    default: "127.0.0.1:17009"

--- a/jobs/datadog-route-emitter/templates/http_check.yaml.erb
+++ b/jobs/datadog-route-emitter/templates/http_check.yaml.erb
@@ -1,0 +1,11 @@
+init_config: {}
+
+instances:
+  - name: route_emitter debug endpoint
+    url: http://localhost:<%= p('diego.route_emitter.debug_addr').split(':')[1] %>/debug/pprof/cmdline
+    collect_response_time: true
+    http_response_status_code: 200
+  - name: route_emitter consul lock
+    url: http://localhost:8500/v1/kv/v1/locks/route_emitter_lock
+    collect_response_time: true
+    http_response_status_code: 200

--- a/jobs/datadog-route-emitter/templates/process.yaml.erb
+++ b/jobs/datadog-route-emitter/templates/process.yaml.erb
@@ -1,0 +1,6 @@
+init_config:
+
+instances:
+  - name: route-emitter
+    search_string: ['route-emitter']
+    exact_match: true


### PR DESCRIPTION
[#131375807 Check health of route emitter component](https://www.pivotaltracker.com/story/show/131375807)

What?
----

We want to monitor the route_emitter as we do with other processes.


We add checks for the Diego Route Emitter process, including:
 * Monitor if the route_emitter process process is present
 * Monitor if the debug HTTP endpoint is open and responds.
 * Monitor if the local consul has the route_emitter lock
   The lock is not necessarily own by the route_emitter in this host.

We also add a example in the bosh-lite manifest.

Dependencies
------------

https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease/pull/9 can be used for testing and review, but does not need to be merged. That PR is based on https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease/pull/7.

How to test
------------

Like in https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease/pull/7, using the example of https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease/pull/9

Check if the process and endpoints added are monitored in datadog.

Who?
---

Anyone but @keymon