### PR TITLE
[#135948443] Check of debug port of garden is optional

### DIFF
--- a/jobs/datadog-garden/spec
+++ b/jobs/datadog-garden/spec
@@ -9,4 +9,3 @@ templates:
 properties:
   garden.debug_listen_address:
     description: "tcp address on which to serve debug info"
-    default: "0.0.0.0:17013"

--- a/jobs/datadog-garden/templates/http_check.yaml.erb
+++ b/jobs/datadog-garden/templates/http_check.yaml.erb
@@ -1,7 +1,12 @@
 init_config: {}
 
+<% if_p("garden.debug_listen_address") do |debug_listen_address| %>
+<% debug_ip, debug_port = debug_listen_address.split(":") %>
 instances:
   - name: garden debug endpoint
-    url: http://localhost:<%= p('garden.debug_listen_address').split(':')[1] %>/debug/pprof/cmdline
+    url: http://<%= debug_ip %>:<%= debug_port %>/debug/pprof/cmdline
     collect_response_time: true
     http_response_status_code: 200
+<% else %>
+instances: []
+<% end %>


### PR DESCRIPTION
What?
------

The debug listen address has been made optional in garden[1], so we must
remove the default value from the spec. We add logic to not configure
the check if the value is not defined

This would remove the error: https://app.datadoghq.com/event/event?id=3719219820021947444

We make the datadog check optional based on the commit in garden-runc-release
[1] https://github.com/cloudfoundry/garden-runc-release/commit/e22d9bf5143d9b9dbd3c2d4abd68d9c52a64d999

How to review?
-----------------

Code test. You can review and merge this before the other  PR #12, so they go together.
