### PR TITLE
[#130660899] Add new job datadog-consul for consul integration

### DIFF
--- a/jobs/datadog-consul/spec
+++ b/jobs/datadog-consul/spec
@@ -5,8 +5,21 @@ packages: []
 templates:
   process.yaml.erb: config/datadog-integrations/process.yaml
   tcp_check.yaml.erb: config/datadog-integrations/tcp_check.yaml
+  consul.yaml.erb: config/datadog-integrations/consul.yaml
 
 properties:
   consul.port:
     description: "Port on which we expect the consul agent listening."
     default: 8301
+  datadog.consul.monitor_url:
+    description: "URL for the datadog agent to connect to consul to monitor the integration. use nil to disable the integration."
+    default: http://localhost:8500
+  datadog.consul.network_latency_checks:
+    description: "Whether to enable network latency metrics collection. When enabled consul network coordinates will be retrieved and latency calculated for each node and between data centers"
+    default: false
+  datadog.consul.service_whitelist:
+    description: "List of services to monitor. Use `nil` to monitor all services (up to 50). Use [] to monitor none"
+    default: []
+  datadog.consul.tags:
+    description: "Additional tags to apply to the metrics, events and service checks"
+    default: []

--- a/jobs/datadog-consul/spec
+++ b/jobs/datadog-consul/spec
@@ -5,12 +5,16 @@ packages: []
 templates:
   process.yaml.erb: config/datadog-integrations/process.yaml
   tcp_check.yaml.erb: config/datadog-integrations/tcp_check.yaml
+  http_check.yaml.erb: config/datadog-integrations/http_check.yaml
   consul.yaml.erb: config/datadog-integrations/consul.yaml
 
 properties:
   consul.port:
     description: "Port on which we expect the consul agent listening."
     default: 8301
+  consul.server_port:
+    description: "Server port on which we expect the consul agent listening."
+    default: 8300
   datadog.consul.monitor_url:
     description: "URL for the datadog agent to connect to consul to monitor the integration. use nil to disable the integration."
     default: http://localhost:8500

--- a/jobs/datadog-consul/templates/consul.yaml.erb
+++ b/jobs/datadog-consul/templates/consul.yaml.erb
@@ -1,0 +1,51 @@
+<% if_p("datadog.consul.monitor_url") do  %>
+# This check takes no init_config
+init_config:
+
+instances:
+    - url: <%= p('datadog.consul.monitor_url') %>
+
+      # Whether to perform checks against the Consul service Catalog
+      catalog_checks: yes
+
+      # Whether to enable self leader checks. Each instance with this enabled will
+      # watch for itself to become the leader and will emit an event when that
+      # happens. It is safe/expected to enable this on all nodes in a consul
+      # cluster since only the new leader will emit the (single) event. This
+      # flag takes precedence over new_leader_checks.
+      self_leader_check: yes
+
+      # Whether to enable new leader checks from this instance
+      # Note: if this is set on multiple instances/agents in the same cluster
+      # you will receive one event per leader change per instance. See
+      # self_leader_check for a more robust option.
+      new_leader_checks: yes
+
+      # Whether to enable network latency metrics collection. When enabled
+      # consul network coordinates will be retrieved and latency calculated for
+      # each node and between data centers.
+      # See https://www.consul.io/docs/internals/coordinates.html
+      <% if p("datadog.consul.network_latency_checks") == "true" or
+            p("datadog.consul.network_latency_checks") == "yes" or
+            p("datadog.consul.network_latency_checks")
+      %>
+      network_latency_checks: yes
+      <% else %>
+      network_latency_checks: no
+      <% end %>
+
+      # Services to restrict catalog querying to
+      <% if_p("datadog.consul.service_whitelist") do |service_whitelist| %>
+      service_whitelist: [<%= service_whitelist.join(',') %>]
+      <% end %>
+
+      <% if_p("datadog.consul.tags") do |tags|
+         if not tags.empty? %>
+      # Additional tags to apply to the metrics, events and service checks
+      # You should always specify tags when multiple instances of the check run
+      # on the same agent.
+      tags: <% tags.map do |k, v| %>
+        - <%= k %>:<%= v %><% end %>
+      <% end
+         end %>
+<% end %>

--- a/jobs/datadog-consul/templates/http_check.yaml.erb
+++ b/jobs/datadog-consul/templates/http_check.yaml.erb
@@ -1,0 +1,10 @@
+<% if_p("datadog.consul.monitor_url") do  %>
+init_config: {}
+
+instances:
+  - name: consul_is_leader
+    url: <%= p('datadog.consul.monitor_url') %>/v1/status/leader
+    collect_response_time: true
+    http_response_status_code: 200
+    content_match: "<%= spec.address %>:<%= p('consul.server_port') %>"
+<% end %>

--- a/manifests/boilerplate/consul.yml
+++ b/manifests/boilerplate/consul.yml
@@ -6,6 +6,11 @@ releases:
   sha1: 7277c80002fee91895bda933f7fbc64395b5240e
 
 properties:
+  datadog:
+    consul:
+      service_whitelist: ['service-a', 'service-b']
+      tags:
+        deployment: bosh-lite
   consul:
     agent:
       domain: cf.internal

--- a/manifests/manifest-bosh-lite.yml
+++ b/manifests/manifest-bosh-lite.yml
@@ -60,6 +60,8 @@ jobs:
     release: datadog-for-cloudfoundry
   - name: datadog-garden
     release: datadog-for-cloudfoundry
+  - name: datadog-consul
+    release: datadog-for-cloudfoundry
   instances: 1
   resource_pool: default
   networks:


### PR DESCRIPTION
[#130660899 Monitor that single instance services are single instance (forever alone)](https://www.pivotaltracker.com/story/show/130660899)

What?
----

We want to be able to get metrics from consul, so that we can get leader election events and monitor the services and consul cluster health from datadog.

For that we add a new job, datadog-consul. This new job would enable the datadog consul integration, allowing tune some of the settings.

You can disable the services metrics by setting a empty service whitelist.

Dependencies
-----------------

You can also review #11 with this

How to test?
-----------

You can do code review.

Recommended: Review this PR in paas-cf to test this one: https://github.com/alphagov/paas-cf/pull/748


Otherwise, you can also use bosh-lite

```bash
cd paas-cf
cd ..
git clone https://github.com/keymon/bosh-lite.git # Use this patched version to use STS credentials https://github.com/cloudfoundry/bosh-lite/pull/417

BOSH_AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN DEPLOY_ENV=hector ./scripts/bosh-lite.sh bosh start
bosh target ...
bosh login

bosh upload stemcell https://bosh.io/d/stemcells/bosh-warden-boshlite-ubuntu-trusty-go_agent


cd paas-datadog-for-cloudfoundry

bosh create release --with-tarball --name datadog-for-cloudfoundry

bosh upload release $(ls -tr dev_releases/datadog-for-cloudfoundry/datadog-for-cloudfoundry-*.tgz | tail -1)

./manifest/build-manifest.sh  > /tmp/manifest.yml
bosh deployment /tmp/manifest.yml
bosh deploy

```

You can SSH on the cell VM by running:

```
cd paas-cf
BOSH_AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN DEPLOY_ENV=hector ./scripts/bosh-lite.sh manifest /tmp/manifest.yml
BOSH_AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN DEPLOY_ENV=hector ./scripts/bosh-lite.sh bosh ssh cell
```

Check the datadog config:

```
cat /var/vcap/jobs/datadog-consul/config/datadog-integrations/consul.yaml
```

Who?
----

Anyone but @keymon