### PR TITLE
Fix unexpected keyword_else

### DIFF
--- a/jobs/datadog-garden/templates/http_check.yaml.erb
+++ b/jobs/datadog-garden/templates/http_check.yaml.erb
@@ -1,12 +1,10 @@
-init_config: {}
-
 <% if_p("garden.debug_listen_address") do |debug_listen_address| %>
 <% debug_ip, debug_port = debug_listen_address.split(":") %>
+init_config: {}
+
 instances:
   - name: garden debug endpoint
     url: http://<%= debug_ip %>:<%= debug_port %>/debug/pprof/cmdline
     collect_response_time: true
     http_response_status_code: 200
-<% else %>
-instances: []
 <% end %>


### PR DESCRIPTION
## What

In https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease/pull/11 we introduced and expression that checks if `debug_listen_address` property is set and in case it's empty sets `instances` of DD check to '[]'. This resulted in:
```
Error 100: Unable to render instance groups for deployment. Errors are:
   - Unable to render jobs for instance group 'cell'. Errors are:
     - Unable to render templates for job 'datadog-garden'. Errors are:
       - Error filling in template '(unknown)' (line (unknown): datadog-garden/http_check.yaml.erb:10: syntax error, unexpected keyword_else, expecting keyword_end
      ;  else ; _erbout.concat "\ninstances: []\n"
             ^)
``` 

if_p != if/else/end.

Now in case debug_listen_address is not defined we leave file empty as there are no check instances.

## How to test 

Use dev release to test on paas-cf

## Who 

Not @mtekel or @combor