### PR TITLE
Empty file results in 'empty hash' DD error

### DIFF
--- a/jobs/datadog-garden/templates/http_check.yaml.erb
+++ b/jobs/datadog-garden/templates/http_check.yaml.erb
@@ -1,6 +1,6 @@
+init_config: {}
 <% if_p("garden.debug_listen_address") do |debug_listen_address| %>
 <% debug_ip, debug_port = debug_listen_address.split(":") %>
-init_config: {}
 
 instances:
   - name: garden debug endpoint


### PR DESCRIPTION
## What
This is follow up to https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease/pull/14

We need to put init_config: {} in the config as DD complains about
empty hash without it.

# How 

Sanity check

## Who 

@paroxp 