### PR TITLE
[#139196683] Remove protocol and path from url property

### DIFF
--- a/jobs/datadog-bbs/spec
+++ b/jobs/datadog-bbs/spec
@@ -9,7 +9,7 @@ templates:
 properties:
   bbs.url:
     description: "URL of BBS API"
-    default: "https://localhost:8889"
+    default: "https://localhost:8889/v1/ping"
   bbs.timeout:
     description: "BBS connection timeout"
   bbs.client_cert:

--- a/jobs/datadog-bbs/templates/bbs_check.yaml.erb
+++ b/jobs/datadog-bbs/templates/bbs_check.yaml.erb
@@ -2,7 +2,7 @@ init_config:
   default_timeout: 5
 instances:
   - name: BBS
-    url: https://<%= p('bbs.url')%>/v1/actual_lrp_groups/list
+    url: <%= p('bbs.url')%>
     <% if_p('bbs.timeout') do %>
     timeout: <%= p('bbs.timeout') %>
     <% end %>


### PR DESCRIPTION
## What

To avoid conflicts with defaults we decided to pass entire URL string
to the `instances.url` property not just a hostname.

## How to test

Together with https://github.com/alphagov/paas-cf/pull/818

## Who
Not me