### PR TITLE
[#139179971] Change garden process name

### DIFF
--- a/jobs/datadog-garden/templates/process.yaml.erb
+++ b/jobs/datadog-garden/templates/process.yaml.erb
@@ -2,4 +2,4 @@ init_config:
 
 instances:
   - name: guardian
-    search_string: ['guardian']
+    search_string: ['gdn']


### PR DESCRIPTION
# What

Story: [Upgrade CF to >= v252](https://www.pivotaltracker.com/story/show/139179971)

This garden process name has changed from 'garden' to 'gdn' when CF was upgraded to v253. The monitor must be updated.

# How to review
Deploy with paas-cf PR https://github.com/alphagov/paas-cf/pull/838

# Who can review
Not me
