### PR TITLE
[#145037767] Add new job to monitor CDN broker

### DIFF
--- a/jobs/datadog-cdn-broker/spec
+++ b/jobs/datadog-cdn-broker/spec
@@ -1,0 +1,11 @@
+---
+name: datadog-cdn-broker
+packages: []
+
+templates:
+  http_check.yaml.erb: config/datadog-integrations/http_check.yaml
+
+properties:
+  cdn-broker.port:
+    description: "Listening port for CDN broker."
+    default: 3000

--- a/jobs/datadog-cdn-broker/templates/http_check.yaml.erb
+++ b/jobs/datadog-cdn-broker/templates/http_check.yaml.erb
@@ -1,0 +1,7 @@
+init_config: {}
+
+instances:
+  - name: cdn_broker
+    url: http://localhost:<%= p('cdn-broker.port') %>/healthcheck
+    collect_response_time: true
+    http_response_status_code: 200


### PR DESCRIPTION
## What

Which queries the new healthcheck endpoint which checks all dependencies
added in alphagov/paas-cdn-broker#3

I'm not adding this to the bosh-lite manifests because we don't have the
BOSH releases for the CDN broker deployed here and I don't think it makes
sense to add them.

I was hoping to set `include_content` so that the monitor contained
information about which healthchecks have failed, but it's not supported by
the version of the agent that we're currently using. I considered leaving it
in so that it works one day but I thought it might be confusing in the
meantime.

- http://docs.datadoghq.com/integrations/httpcheck/

## How to review
* Test https://github.com/alphagov/paas-cf/pull/934 instead, as it uses this.

🐝 🐝 🐝 🐝 🐝 🐝 🐝
This must be merged before https://github.com/alphagov/paas-cf/pull/934 and the temp commit updated.
🐝 🐝 🐝 🐝 🐝 🐝 🐝 

## Who can review 

Anyone.