### PR TITLE
[#145682111] Fix Nats Stream Forwarder process check

### DIFF
--- a/jobs/datadog-nats/templates/process.yaml.erb
+++ b/jobs/datadog-nats/templates/process.yaml.erb
@@ -5,5 +5,5 @@ instances:
     search_string: ['gnatsd']
 
   - name: nats_stream_forwarder
-    search_string: ['ruby /var/vcap/jobs/nats_stream_forwarder/bin/nats_stream_forwarder.rb']
+    search_string: ['/var/vcap/jobs/nats_stream_forwarder/bin/nats_stream_forwarder.rb']
     exact_match: False


### PR DESCRIPTION
## What

The search string no longer works with the version of the Nats
Stream Forwarder that ships with cf-release v264, so it breaks
our Datadog monitor.

## How to review

We need to assert that if this job is deployed to the nats VMs the '<env> NATS stream forwarder process running' monitor is no longer triggered.

I think the proper way of doing this (deploy CF v264 with a dev release of this Bosh release) would take too long, because these pull requests are cheap to make and the process would be lengthy. I recommend using Bosh SSH to access a nats VM in ci, listing all processes, and `grep` for the new search string. You should be able to see the nats_stream_forwarder process.

Once this is done we need a separate pull request on paas-cf to use the new 'final' release.

## Who

Anyone but me.