### PR TITLE
[#155178552] Monitoring of logsearch queue redis key size

### DIFF
--- a/jobs/datadog-logsearch-queue/spec
+++ b/jobs/datadog-logsearch-queue/spec
@@ -1,0 +1,14 @@
+---
+name: datadog-logsearch-queue
+packages: []
+
+templates:
+  redisdb.yaml.erb: config/datadog-integrations/redisdb.yaml
+
+properties:
+  redis.port:
+    description: Redis port of queue
+    default: 6379
+  redis.key:
+    description: Name of queue to pull messages from
+    default: logstash

--- a/jobs/datadog-logsearch-queue/templates/redisdb.yaml.erb
+++ b/jobs/datadog-logsearch-queue/templates/redisdb.yaml.erb
@@ -1,0 +1,78 @@
+init_config:
+
+instances:
+  - host: localhost
+    port: <%= p('redis.port') %>
+
+    # Can be used in lieu of host/port
+    #
+    # unix_socket_path: /var/run/redis/redis.sock # optional, can be used in lieu of host/port
+
+    # Addional connection options
+    #
+    # db: 0
+    # password: mypassword
+    # socket_timeout: 5
+
+    # Optional SSL/TLS parameters
+    # ssl: False     # Optional (default to False)
+    # ssl_keyfile:   # Path to the client-side private keyfile
+    # ssl_certfile:  # Path to the client-side certificate file
+    # ssl_ca_certs:  #  Path to the ca_certs file
+    # ssl_cert_reqs: # Specifies whether a certificate is required from the
+    #                # other side of the connection, and whether it will be validated if
+    #                # provided.
+    #   * 0 for ssl.CERT_NONE (certificates ignored)
+    #   * 1 for ssl.CERT_OPTIONAL (not required, but validated if provided)
+    #   * 2 for ssl.CERT_REQUIRED (required and validated)
+
+    # Optional extra tags added to all redis metrics
+    # tags:
+    #   - optional_tag1
+    #   - optional_tag2
+    #
+
+    # Collect the lengths of the following keys.
+    # Length is zero for keys that have a type other than list, set, hash, or sorted set.
+    # Keys can be expressed as patterns, see https://redis.io/commands/keys
+    keys:
+      - <%= p('redis.key') %>
+    #   - key2
+    #   - key* (matches key, key1 and key2)
+
+    # If you provide a list of 'keys', have the Agent log a warning when keys are missing.
+    # (default: True)
+    #
+    # warn_on_missing_keys: True
+
+    # Max number of entries to fetch from the slow query log
+    # By default, the check will read this value from the redis config
+    # If it's above 128, it will default to 128 due to potential increased latency
+    # to retrieve more than 128 slowlog entries every 15 seconds
+    # If you need to get more entries from the slow query logs
+    # set the value here.
+    # Warning: It may impact the performance of your redis instance
+    # slowlog-max-len: 128
+
+    # Collect INFO COMMANDSTATS output as metrics.
+    # command_stats: False
+
+## Log Section (Available for Agent >=6.0)
+
+#logs:
+
+    # - type : (mandatory) type of log input source (tcp / udp / file)
+    #   port / path : (mandatory) Set port if type is tcp or udp. Set path if type is file
+    #   service : (mandatory) name of the service owning the log
+    #   source : (mandatory) attribute that defines which integration is sending the logs
+    #   sourcecategory : (optional) Multiple value attribute. Can be used to refine the source attribtue
+    #   tags: (optional) add tags to each logs collected
+
+    # - type: file
+    #   path: /var/log/redis_6379.log
+    #   source: redis
+    #   sourcecategory: database
+    #   service: myapplication
+
+
+


### PR DESCRIPTION
[#155178552 Monitor Redis queue length for ELK stack](https://www.pivotaltracker.com/story/show/155178552)


What?
----

We would enable the redis integration from datadog[1] to monitor
the logsearch queue size[2] in the default key for the job.

[1] https://docs.datadoghq.com/integrations/redisdb/
[2] https://github.com/logsearch/logsearch-boshrelease/blob/v203.0.0/jobs/queue/spec#L14-L19

How to test?
-------
This can be tested as part of https://github.com/alphagov/paas-cf/pull/1235


Who?
---

Anyone but @keymon or @bandesz