### PR TITLE
[#155398419] Chown config files to vcap:vcap and upgrade from upstream

### DIFF
--- a/manifests/boilerplate/datadog.yml
+++ b/manifests/boilerplate/datadog.yml
@@ -1,9 +1,9 @@
 ---
 releases:
 - name: datadog-agent
-  sha1: 14c7f9be2eb534fda1f4c70ea2355865ac93a87b
-  url: https://github.com/alphagov/paas-datadog-agent-boshrelease/releases/download/v5.8.5.3-gds/datadog-agent-v5.8.5.3-gds.tgz
-  version: "v5.8.5.3-gds"
+  sha1: 573bed2ab7960eb97dafff4b7c6111e7ad72b39c
+  url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/datadog-agent-0.1.5.tgz
+  version: 0.1.5
 
 properties:
   api_key: (( grab $DATADOG_API_KEY || "undefined" ))


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/155398419

## What

Update datadog-agent BOSH release. See https://github.com/alphagov/paas-datadog-agent-boshrelease/pull/13 for details.

❗️ This PR contains a temporary commit which needs to be replaced when the final datadog-agent release is built.

## How to review

Code review.

To test it follow the instructions from:
 * https://github.com/alphagov/paas-cf/pull/1256

## Who can review it

Not me.