### PR TITLE
[#155623416] Remove route-emitter consul lock check

### DIFF
--- a/jobs/datadog-route-emitter/templates/http_check.yaml.erb
+++ b/jobs/datadog-route-emitter/templates/http_check.yaml.erb
@@ -5,7 +5,3 @@ instances:
     url: http://localhost:<%= p('diego.route_emitter.debug_addr').split(':')[1] %>/debug/pprof/cmdline
     collect_response_time: true
     http_response_status_code: 200
-  - name: route_emitter consul lock
-    url: http://localhost:8500/v1/kv/v1/locks/route_emitter_lock
-    collect_response_time: true
-    http_response_status_code: 200


### PR DESCRIPTION
## What

We have switched to cell-local route-emitters, so no longer have to
maintain locking. Each route-emitter process will be solely responsible
for the routes to containers on the VM on which it is running.

## How to review

Review as part of https://github.com/alphagov/paas-cf/pull/1263
Code review to see if anything relevant was missed. I think actually trying to deploy this will take too much time.

The dev Bosh release has already built successfully: https://concourse.build.ci.cloudpipeline.digital/teams/main/pipelines/datadog-for-cloudfoundry-release/jobs/build-dev-release/builds/81

Once merged we need to get the final release details to add to the related pull request in paas-cf

## Who

Anyone but me or @keymon 