### PR TITLE
[#155936773] Use spec.job.name for CC worker process search

### DIFF
--- a/jobs/datadog-cc-worker/templates/process.yaml.erb
+++ b/jobs/datadog-cc-worker/templates/process.yaml.erb
@@ -2,7 +2,7 @@ init_config:
 
 instances:
   - name: cc api worker
-    search_string: ['cc_global_worker.api_worker']
+    search_string: ['cc_global_worker.<%= spec.job.name %>']
     exact_match: false
     thresholds:
       critical: [<%= p('cc.jobs.generic.number_of_workers') %>, <%= p('cc.jobs.generic.number_of_workers') %>]

--- a/jobs/datadog-cc/templates/process.yaml.erb
+++ b/jobs/datadog-cc/templates/process.yaml.erb
@@ -6,7 +6,7 @@ instances:
     exact_match: false
 <% if p('cc.jobs.local.number_of_workers').to_i > 0 %>
   - name: cc api worker
-    search_string: ['cc_api_worker.api']
+    search_string: ['cc_api_worker.<%= spec.job.name %>']
     exact_match: false
     thresholds:
       critical: [<%= p('cc.jobs.local.number_of_workers') %>, <%= p('cc.jobs.local.number_of_workers') %>]


### PR DESCRIPTION
What?
-----

After the PR https://github.com/alphagov/paas-cf/pull/1263 where we renamed the workers of CC we are having a monitor in datadog failing.

The process running the worker is parametrised with the name
of the job (aka `instance_group`)[1].

We need to use the variable spec.job.name in order to make the check
agnostic to the job/instance_group name.

[1] https://github.com/cloudfoundry/capi-release/blob/2f640cdca2f13925f0993a16502119128196de0b/jobs/cloud_controller_worker/templates/bin/cloud_controller_worker.erb#L13

How to review?
-------------

Code review or review with https://github.com/alphagov/paas-cf/pull/1275

Who?
----

Anyone but @keymon