### PR TITLE
[#155592565] Get nats.port from BOSH link if present

### DIFF
--- a/jobs/datadog-nats/spec
+++ b/jobs/datadog-nats/spec
@@ -6,6 +6,11 @@ templates:
   process.yaml.erb: config/datadog-integrations/process.yaml
   tcp_check.yaml.erb: config/datadog-integrations/tcp_check.yaml
 
+consumes:
+- name: nats
+  type: nats
+  optional: true
+
 properties:
   nats.port:
     description: "Listening Port for NATS server."

--- a/jobs/datadog-nats/templates/tcp_check.yaml.erb
+++ b/jobs/datadog-nats/templates/tcp_check.yaml.erb
@@ -1,9 +1,16 @@
+<%=
+  nats_port = p('nats.port')
+  respond_to?(:if_link) && if_link("nats") do |link|
+    nats_port = link.p("nats.port")
+  end
+%>
+
 init_config:
 
 instances:
   - name: NATS server
     host: <%= spec.address %>
-    port: <%= p('nats.port') %>
+    port: <%= nats_port %>
     collect_response_time: true
 
   - name: NATS cluster


### PR DESCRIPTION
## What

Get nats.port from BOSH link if present

Using BOSH links we don't have to explicitly pass the NATS port which is safer
and a lot more convenient :)

## How to review

Review as part of https://github.com/alphagov/paas-cf/pull/1277

## Who can review it

Not @camelpunch or me.