### PR TITLE
[#156188483] Revert BOSH link

### DIFF
--- a/jobs/datadog-nats/spec
+++ b/jobs/datadog-nats/spec
@@ -6,11 +6,6 @@ templates:
   process.yaml.erb: config/datadog-integrations/process.yaml
   tcp_check.yaml.erb: config/datadog-integrations/tcp_check.yaml
 
-consumes:
-- name: nats
-  type: nats
-  optional: true
-
 properties:
   nats.port:
     description: "Listening Port for NATS server."

--- a/jobs/datadog-nats/templates/tcp_check.yaml.erb
+++ b/jobs/datadog-nats/templates/tcp_check.yaml.erb
@@ -1,16 +1,9 @@
-<%=
-  nats_port = p('nats.port')
-  respond_to?(:if_link) && if_link("nats") do |link|
-    nats_port = link.p("nats.port")
-  end
-%>
-
 init_config:
 
 instances:
   - name: NATS server
     host: <%= spec.address %>
-    port: <%= nats_port %>
+    port: <%= p('nats.port') %>
     collect_response_time: true
 
   - name: NATS cluster


### PR DESCRIPTION
## What

Revert "Merge pull request #25 from alphagov/use_bosh_links_155592565"

This reverts commit 0d4f36a0d52cef82df4066e77acb44817708c331, reversing
changes made to ddc8e41402bb0766cce388ab2c5775f4370871ec.

The nats instances are always redeployed by BOSH because of an unknown issue. Not consuming the link from the job doesn't solve the issue, so we suspect there might be an issue with how we handle the link in the template. We opened an issue in the BOSH project [1].

[1] https://github.com/cloudfoundry/bosh/issues/1923

## How to review

Review as part of https://github.com/alphagov/paas-cf/pull/1295.

## Who can review

Not me.