### PR TITLE
[#156188483] Fix check template for datadog-nats

### DIFF
--- a/jobs/datadog-nats/templates/tcp_check.yaml.erb
+++ b/jobs/datadog-nats/templates/tcp_check.yaml.erb
@@ -1,4 +1,4 @@
-<%=
+<%
   nats_port = p('nats.port')
   respond_to?(:if_link) && if_link("nats") do |link|
     nats_port = link.p("nats.port")


### PR DESCRIPTION
## What

We accidentally used `<%=` instead of `<%` which printed the object reference
to the template.

The generated template looked something like this:
```
#<Bosh::Template::EvaluationContext::InactiveElseBlock:0x00007fdd049545f0>

init_config:
...
```

See https://github.com/cloudfoundry/bosh/issues/1923 for details.

## How to review

Review as part of https://github.com/alphagov/paas-cf/pull/1295

## Who can review

Not me