### PR TITLE
[#156570305] Remove rep service endpoint check

### DIFF
--- a/jobs/datadog-rep/templates/http_check.yaml.erb
+++ b/jobs/datadog-rep/templates/http_check.yaml.erb
@@ -1,10 +1,6 @@
 init_config: {}
 
 instances:
-  - name: rep service endpoint
-    url: http://localhost:<%= p('diego.rep.listen_addr').split(':')[1] %>/ping
-    collect_response_time: true
-    http_response_status_code: 200
   - name: rep debug endpoint
     url: http://localhost:<%= p('diego.rep.debug_addr').split(':')[1] %>/debug/pprof/cmdline
     collect_response_time: true


### PR DESCRIPTION
## What

After the upgrade done in [1], the rep service endpoint check is broken, as it uses mutual TLS.

[1] https://www.pivotaltracker.com/story/show/156299675

## How to review

Code review should be enough. I don't think it's worth to do a full Datadog enabled dev deploy for this.

## How can review it

Not me.