### PR TITLE
Add simple process healthcheck for bosh-dns

### DIFF
--- a/jobs/datadog-bosh-dns/spec
+++ b/jobs/datadog-bosh-dns/spec
@@ -1,0 +1,7 @@
+---
+name: datadog-bosh-dns
+packages: []
+
+templates:
+  process.yaml.erb: config/datadog-integrations/bosh_dns_process.yaml
+

--- a/jobs/datadog-bosh-dns/templates/process.yaml.erb
+++ b/jobs/datadog-bosh-dns/templates/process.yaml.erb
@@ -1,0 +1,7 @@
+init_config:
+
+instances:
+  - name: bosh-dns
+    search_string: ['/var/vcap/packages/bosh-dns/bin/bosh-dns ']
+    exact_match: false
+


### PR DESCRIPTION
It looks like the http healthcheck may be only available over mutual TLS
- since it might be tricky to persuade datadog to do this we're starting
with just a simple process check.