### PR TITLE
Fix the path to bosh-dns's process.yaml

### DIFF
--- a/jobs/datadog-bosh-dns/spec
+++ b/jobs/datadog-bosh-dns/spec
@@ -3,5 +3,5 @@ name: datadog-bosh-dns
 packages: []
 
 templates:
-  process.yaml.erb: config/datadog-integrations/bosh_dns_process.yaml
+  process.yaml.erb: config/datadog-integrations/process.yaml
 


### PR DESCRIPTION
It looks like the name process.yaml is special to datadog, it won't
work properly if the file is called `bosh_dns_process.yaml`.

It is ok to give the file the same name as all the other process checks
because the config directory lives in `/var/vcap/jobs/datadog-bosh-dns/`
so it's obvious what it's for.