### PR TITLE
[#159136460] Assert on Consul leader IP not DNS name

### DIFF
--- a/jobs/datadog-consul-agent-server/templates/http_check.yaml.erb
+++ b/jobs/datadog-consul-agent-server/templates/http_check.yaml.erb
@@ -6,5 +6,5 @@ instances:
     url: <%= p('datadog.consul.monitor_url') %>/v1/status/leader
     collect_response_time: true
     http_response_status_code: 200
-    content_match: "<%= spec.address %>:<%= p('consul.server_port') %>"
+    content_match: "<%= spec.ip %>:<%= p('consul.server_port') %>"
 <% end %>


### PR DESCRIPTION
What
----

As part of the BOSH DNS we also changed BOSH to use DNS names rather
than IPs[1]. Our Datadog monitor previously was relying on Consul
reporting its leader by IP, `spec.address` can return a DNS name rather
than an IP. `spec.ip` will explicitly return an IP.

[1] https://github.com/alphagov/paas-bootstrap/commit/5603e83af550e4a1682ad03262a809b94af3eefd#diff-e02637e826c754aeb7f803eb9abac62bR101

How to review
-------------

Short cut: check that `spec.ip` is available as we're using bosh release v258 or later (https://bosh.io/docs/jobs/#properties-spec).

Long way around:

- take the release generated by this PR, and roll it down a dev env with datadog integrations enabled
- check that the `<env name> consul cluster has at least one leader` datadog monitor is not red

Who can review
--------------

Anyone except @samcrang or myself.